### PR TITLE
fix: update package name where imports are incompatible with source repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ services with [manifold cli](https://github.com/manifoldco/manifold-cli).
 [Code of Conduct](./CODE_OF_CONDUCT.md) |
 [Contribution Guidelines](./.github/CONTRIBUTING.md)
 
-[![GitHub release](https://img.shields.io/github/tag/manifoldco/promptui.svg?label=latest)](https://github.com/manifoldco/promptui/releases)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/manifoldco/promptui)
+[![GitHub release](https://img.shields.io/github/tag/SimFG/promptui.svg?label=latest)](https://github.com/SimFG/promptui/releases)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/SimFG/promptui)
 [![Travis](https://img.shields.io/travis/manifoldco/promptui/master.svg)](https://travis-ci.org/manifoldco/promptui)
-[![Go Report Card](https://goreportcard.com/badge/github.com/manifoldco/promptui)](https://goreportcard.com/report/github.com/manifoldco/promptui)
+[![Go Report Card](https://goreportcard.com/badge/github.com/SimFG/promptui)](https://goreportcard.com/report/github.com/SimFG/promptui)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](./LICENSE.md)
 
 ## Overview
@@ -31,7 +31,7 @@ Promptui has two main input modes:
 - `Select` provides a list of options to choose from. Select supports
   pagination, search, detailed view and custom templates.
 
-For a full list of options check [GoDoc](https://godoc.org/github.com/manifoldco/promptui).
+For a full list of options check [GoDoc](https://godoc.org/github.com/SimFG/promptui).
 
 ## Basic Usage
 
@@ -45,7 +45,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/manifoldco/promptui"
+	"github.com/SimFG/promptui"
 )
 
 func main() {
@@ -81,7 +81,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/manifoldco/promptui"
+	"github.com/SimFG/promptui"
 )
 
 func main() {
@@ -104,4 +104,4 @@ func main() {
 
 ### More Examples
 
-See full list of [examples](https://github.com/manifoldco/promptui/tree/master/_examples)
+See full list of [examples](https://github.com/SimFG/promptui/tree/master/_examples)

--- a/_examples/checkbox/main.go
+++ b/_examples/checkbox/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/manifoldco/promptui"
+	"github.com/SimFG/promptui"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/manifoldco/promptui
+module github.com/SimFG/promptui
 
 go 1.18
 

--- a/prompt.go
+++ b/prompt.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 
 	"github.com/chzyer/readline"
-	"github.com/manifoldco/promptui/screenbuf"
+	"github.com/SimFG/promptui/screenbuf"
 )
 
 // Prompt represents a single line text field input with options for validation and input masks.

--- a/select.go
+++ b/select.go
@@ -9,8 +9,8 @@ import (
 	"text/template"
 
 	"github.com/chzyer/readline"
-	"github.com/manifoldco/promptui/list"
-	"github.com/manifoldco/promptui/screenbuf"
+	"github.com/SimFG/promptui/list"
+	"github.com/SimFG/promptui/screenbuf"
 )
 
 // SelectedAdd is used internally inside SelectWithAdd when the add option is selected in select mode.

--- a/select_test.go
+++ b/select_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/manifoldco/promptui/screenbuf"
+	"github.com/SimFG/promptui/screenbuf"
 )
 
 func TestSelectTemplateRender(t *testing.T) {


### PR DESCRIPTION
I updated `go.mod` and a few other imports that caused the new features from your fork not to work